### PR TITLE
[Fecha o EntityManager ao final de cada Request]

### DIFF
--- a/src/main/java/com/alucarweb/util/EntityManagerProducer.java
+++ b/src/main/java/com/alucarweb/util/EntityManagerProducer.java
@@ -1,24 +1,29 @@
 package com.alucarweb.util;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
-@RequestScoped
+@ApplicationScoped
 public class EntityManagerProducer {
 
+	@Inject
 	private EntityManager entityManager;
 
 	private static EntityManagerFactory factory = Persistence.createEntityManagerFactory("alucar");
 
 	@Produces
+	@RequestScoped
 	public EntityManager getEntityManager() {
+		return entityManager = factory.createEntityManager();
+	}
 
-		if (entityManager == null) {
-			entityManager = factory.createEntityManager();
-		}
-		return entityManager;
+	public void closeEntityManager(@Disposes EntityManager manager) {
+		manager.close();
 	}
 }


### PR DESCRIPTION
Ao final de cada request, o EntityManager não era fechado...continuando na memoria da JVM.
Por isso se fossse realizado varios requests na pagina. iria rodar uma excessao.
### TO TEST
- [x] - Verificar se o fluxo de salvar, pesquisar e editar continua ok
